### PR TITLE
fix(iso-code): pin test repo initial branch to main

### DIFF
--- a/iso-code/src/guards.rs
+++ b/iso-code/src/guards.rs
@@ -186,7 +186,7 @@ pub(crate) fn check_not_network_filesystem(path: &Path) -> Result<(), WorktreeEr
                     let mount_point = parts[1];
                     let fs_type = parts[2];
                     if path_str.starts_with(mount_point)
-                        && network_types.iter().any(|t| fs_type == *t)
+                        && network_types.contains(&fs_type)
                     {
                         return Err(WorktreeError::NetworkFilesystem {
                             mount_point: std::path::PathBuf::from(mount_point),

--- a/iso-code/src/lock.rs
+++ b/iso-code/src/lock.rs
@@ -272,7 +272,7 @@ fn is_network_filesystem(path: &Path) -> bool {
                 }
             }
             if let Some((_, fs)) = best {
-                return network_types.iter().any(|t| fs == *t);
+                return network_types.contains(&fs);
             }
         }
     }

--- a/iso-code/src/manager.rs
+++ b/iso-code/src/manager.rs
@@ -1124,17 +1124,28 @@ mod tests {
     /// Create a temporary git repo for testing.
     fn create_test_repo() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().unwrap();
-        Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "initial"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
+        run_git(dir.path(), &["init", "-b", "main"]);
+        // CI runners typically have no global user.name/user.email; configure
+        // locally so `git commit` below succeeds.
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Test"]);
+        run_git(dir.path(), &["commit", "--allow-empty", "-m", "initial"]);
         dir
+    }
+
+    /// Run a git command in `dir` and panic with stderr if it fails.
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+        if !out.status.success() {
+            panic!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
     }
 
     #[test]

--- a/iso-code/src/manager.rs
+++ b/iso-code/src/manager.rs
@@ -1125,7 +1125,7 @@ mod tests {
     fn create_test_repo() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().unwrap();
         Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(dir.path())
             .output()
             .unwrap();

--- a/iso-code/tests/stress_create_delete.rs
+++ b/iso-code/tests/stress_create_delete.rs
@@ -13,17 +13,27 @@ use iso_code::{Config, CreateOptions, DeleteOptions, Manager};
 
 fn create_test_repo() -> tempfile::TempDir {
     let dir = tempfile::TempDir::new().unwrap();
-    Command::new("git")
-        .args(["init"])
-        .current_dir(dir.path())
-        .output()
-        .unwrap();
-    Command::new("git")
-        .args(["commit", "--allow-empty", "-m", "initial"])
-        .current_dir(dir.path())
-        .output()
-        .unwrap();
+    run_git(dir.path(), &["init", "-b", "main"]);
+    // CI runners typically have no global user.name/user.email; configure
+    // locally so `git commit` below succeeds.
+    run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "Test"]);
+    run_git(dir.path(), &["commit", "--allow-empty", "-m", "initial"]);
     dir
+}
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+    if !out.status.success() {
+        panic!(
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 }
 
 /// Run 100 sequential create/delete cycles and assert that every cycle leaves

--- a/iso-code/tests/stress_gc_orphans.rs
+++ b/iso-code/tests/stress_gc_orphans.rs
@@ -12,17 +12,27 @@ use iso_code::{Config, CreateOptions, DeleteOptions, GcOptions, Manager};
 
 fn create_test_repo() -> tempfile::TempDir {
     let dir = tempfile::TempDir::new().unwrap();
-    Command::new("git")
-        .args(["init"])
-        .current_dir(dir.path())
-        .output()
-        .unwrap();
-    Command::new("git")
-        .args(["commit", "--allow-empty", "-m", "initial"])
-        .current_dir(dir.path())
-        .output()
-        .unwrap();
+    run_git(dir.path(), &["init", "-b", "main"]);
+    // CI runners typically have no global user.name/user.email; configure
+    // locally so `git commit` below succeeds.
+    run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "Test"]);
+    run_git(dir.path(), &["commit", "--allow-empty", "-m", "initial"]);
     dir
+}
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+    if !out.status.success() {
+        panic!(
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 }
 
 /// GC must correctly handle a mix of fresh, stale, and locked worktrees. This


### PR DESCRIPTION
## Summary
- `test_create_worktree_cleanup_on_add_failure` was failing on the `build-and-test (macos-latest)` CI job while passing locally.
- Root cause: `git init` on the macOS Actions runner defaults to `master` (no `init.defaultBranch` global config), so the `main` branch did not yet exist in the scratch repo. The test expects `mgr.create("main", …)` to fail with *branch already checked out* — on CI it instead succeeded by creating a brand-new `main` branch, flipping `assert!(result.is_err())`.
- Fix: pass `-b main` to `git init` in `create_test_repo` so the initial branch is deterministic regardless of the runner's git config.

## Test plan
- [x] `cargo test -p iso-code --lib manager::tests::test_create_worktree_cleanup_on_add_failure` passes locally
- [x] `cargo test -p iso-code --lib` — all 111 tests pass
- [ ] CI `build-and-test (macos-latest)` is green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)