### PR TITLE
ci: create GitHub Release on v* tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
cargo release pushes a tag and publishes to crates.io, but no workflow
was creating a corresponding GitHub Release, so the Releases page lagged
behind crates.io. This adds a tag-triggered workflow that uses
softprops/action-gh-release with auto-generated notes.

https://claude.ai/code/session_01QrNgxnKtypRouxiPySkque