### PR TITLE
fix(cli): reject extra positional args in create/delete/attach (#18)

### DIFF
--- a/iso-code-cli/src/main.rs
+++ b/iso-code-cli/src/main.rs
@@ -98,13 +98,18 @@ fn run_hook(args: &[String]) {
 
     let repo_root = PathBuf::from(&payload.cwd);
 
-    eprintln!("[iso-code] hook received: session={} event={} branch={}",
-        payload.session_id, payload.hook_event_name, payload.name);
+    eprintln!(
+        "[iso-code] hook received: session={} event={} branch={}",
+        payload.session_id, payload.hook_event_name, payload.name
+    );
 
     // Reject traversal tokens in the branch before we use it to build a path.
     // Branch names with `..` would otherwise escape the intended parent dir.
     if payload.name.split('/').any(|seg| seg == ".." || seg == ".") {
-        eprintln!("[iso-code] branch name contains path traversal: {}", payload.name);
+        eprintln!(
+            "[iso-code] branch name contains path traversal: {}",
+            payload.name
+        );
         process::exit(1);
     }
 
@@ -123,9 +128,7 @@ fn run_hook(args: &[String]) {
     // Without this, `feature/auth` would silently create a nested `feature/`
     // directory next to the repo.
     let path_slug = payload.name.replace('/', "-");
-    let wt_path = repo_root.parent()
-        .unwrap_or(&repo_root)
-        .join(&path_slug);
+    let wt_path = repo_root.parent().unwrap_or(&repo_root).join(&path_slug);
 
     let mut opts = CreateOptions::default();
     opts.setup = setup;
@@ -157,9 +160,10 @@ fn run_hook(args: &[String]) {
 
 /// wt list
 fn run_list(args: &[String]) {
-    let repo = args.first().map(PathBuf::from).unwrap_or_else(|| {
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-    });
+    let repo = args
+        .first()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
     let mgr = match Manager::new(&repo, Config::default()) {
         Ok(m) => m,

--- a/iso-code-cli/src/main.rs
+++ b/iso-code-cli/src/main.rs
@@ -188,7 +188,10 @@ fn run_list(args: &[String]) {
 
 /// `wt create <branch> <path>`
 fn run_create(args: &[String]) {
-    if args.len() < 2 {
+    // Exact count, not lower bound: an unquoted path with spaces gets split
+    // by the shell into multiple argv entries. A `<` check silently drops
+    // the trailing chunks and surfaces a misleading downstream error.
+    if args.len() != 2 {
         eprintln!("[iso-code] Usage: wt create <branch> <path>");
         process::exit(1);
     }
@@ -218,7 +221,7 @@ fn run_create(args: &[String]) {
 
 /// `wt delete <path>`
 fn run_delete(args: &[String]) {
-    if args.is_empty() {
+    if args.len() != 1 {
         eprintln!("[iso-code] Usage: wt delete <path>");
         process::exit(1);
     }
@@ -265,7 +268,7 @@ fn run_delete(args: &[String]) {
 
 /// `wt attach <path>` — register an existing external worktree under iso-code management.
 fn run_attach(args: &[String]) {
-    if args.is_empty() {
+    if args.len() != 1 {
         eprintln!("[iso-code] Usage: wt attach <path>");
         process::exit(1);
     }

--- a/iso-code-cli/src/main.rs
+++ b/iso-code-cli/src/main.rs
@@ -188,9 +188,6 @@ fn run_list(args: &[String]) {
 
 /// `wt create <branch> <path>`
 fn run_create(args: &[String]) {
-    // Exact count, not lower bound: an unquoted path with spaces gets split
-    // by the shell into multiple argv entries. A `<` check silently drops
-    // the trailing chunks and surfaces a misleading downstream error.
     if args.len() != 2 {
         eprintln!("[iso-code] Usage: wt create <branch> <path>");
         process::exit(1);

--- a/iso-code-cli/tests/arg_count_validation.rs
+++ b/iso-code-cli/tests/arg_count_validation.rs
@@ -1,0 +1,174 @@
+//! Regression test for issue #18: `wt create`, `wt delete`, and `wt attach`
+//! silently drop extra positional args, producing misleading errors.
+//!
+//! Before the fix, these subcommands validated only a lower bound on argv
+//! count. If the user forgot to quote a path containing spaces, the shell
+//! would split it into multiple tokens and the CLI would take the first
+//! chunk as the path, discarding the rest. The user would then see a
+//! downstream error ("path already exists", "worktree not found", etc.)
+//! instead of a clear usage error.
+//!
+//! Fix: validate exact positional-arg count and emit the existing Usage
+//! message when extras are passed.
+
+/// Run the `wt` binary from a throwaway tempdir that is *not* a git repo.
+/// This way, even if a test regresses and the binary slips past arg
+/// validation into a Manager call, it cannot mutate the real repository
+/// hosting the test suite.
+fn wt(cwd: &std::path::Path) -> assert_cmd::Command {
+    let mut cmd = assert_cmd::Command::cargo_bin("wt").expect("wt binary");
+    cmd.current_dir(cwd);
+    cmd
+}
+
+fn sandbox() -> tempfile::TempDir {
+    tempfile::TempDir::new().expect("tempdir")
+}
+
+/// `wt create a b c` — three positionals where only two are expected.
+/// Must fail fast with the Usage message, not proceed with `a b` and
+/// ignore `c`.
+#[test]
+fn create_rejects_extra_positional_args() {
+    let sb = sandbox();
+    let output = wt(sb.path())
+        .args(["create", "feature/auth", "/tmp/some/path", "extra-arg"])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        !output.status.success(),
+        "wt create with extra args must exit non-zero"
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt create <branch> <path>"),
+        "expected Usage message, got stderr: {stderr}"
+    );
+}
+
+/// `wt delete a b` — two positionals where only one is expected.
+#[test]
+fn delete_rejects_extra_positional_args() {
+    let sb = sandbox();
+    let output = wt(sb.path())
+        .args(["delete", "/tmp/some/path", "extra-arg"])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        !output.status.success(),
+        "wt delete with extra args must exit non-zero"
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt delete <path>"),
+        "expected Usage message, got stderr: {stderr}"
+    );
+}
+
+/// `wt attach a b` — two positionals where only one is expected.
+#[test]
+fn attach_rejects_extra_positional_args() {
+    let sb = sandbox();
+    let output = wt(sb.path())
+        .args(["attach", "/tmp/some/path", "extra-arg"])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        !output.status.success(),
+        "wt attach with extra args must exit non-zero"
+    );
+    assert_eq!(output.status.code(), Some(1));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt attach <path>"),
+        "expected Usage message, got stderr: {stderr}"
+    );
+}
+
+/// Scenario from the issue report: an unquoted path with spaces. The
+/// shell would split this into four argv entries; previously the CLI
+/// would silently take the first as the path and proceed. Now it must
+/// reject with the Usage message.
+#[test]
+fn create_rejects_unquoted_path_with_spaces() {
+    let sb = sandbox();
+    let output = wt(sb.path())
+        .args([
+            "create",
+            "feature/auth",
+            "/Users/kg/Documents/Documents",
+            "-",
+            "kg/projects/foo/bar",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        !output.status.success(),
+        "unquoted path with spaces must exit non-zero"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt create <branch> <path>"),
+        "expected Usage message (not a downstream path error), got stderr: {stderr}"
+    );
+    // The old (buggy) behavior produced "worktree path already exists" or
+    // similar. Make sure we no longer surface that misleading error.
+    assert!(
+        !stderr.contains("already exists"),
+        "must not fall through to a misleading downstream error: {stderr}"
+    );
+}
+
+/// Missing positional args still trigger the Usage message — the
+/// lower-bound behavior is preserved.
+#[test]
+fn create_rejects_too_few_args() {
+    let sb = sandbox();
+    let output = wt(sb.path())
+        .args(["create", "only-one"])
+        .output()
+        .expect("spawn wt");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt create <branch> <path>"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn delete_rejects_zero_args() {
+    let sb = sandbox();
+    let output = wt(sb.path()).args(["delete"]).output().expect("spawn wt");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt delete <path>"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn attach_rejects_zero_args() {
+    let sb = sandbox();
+    let output = wt(sb.path()).args(["attach"]).output().expect("spawn wt");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: wt attach <path>"),
+        "stderr: {stderr}"
+    );
+}

--- a/iso-code-cli/tests/arg_count_validation.rs
+++ b/iso-code-cli/tests/arg_count_validation.rs
@@ -1,20 +1,3 @@
-//! Regression test for issue #18: `wt create`, `wt delete`, and `wt attach`
-//! silently drop extra positional args, producing misleading errors.
-//!
-//! Before the fix, these subcommands validated only a lower bound on argv
-//! count. If the user forgot to quote a path containing spaces, the shell
-//! would split it into multiple tokens and the CLI would take the first
-//! chunk as the path, discarding the rest. The user would then see a
-//! downstream error ("path already exists", "worktree not found", etc.)
-//! instead of a clear usage error.
-//!
-//! Fix: validate exact positional-arg count and emit the existing Usage
-//! message when extras are passed.
-
-/// Run the `wt` binary from a throwaway tempdir that is *not* a git repo.
-/// This way, even if a test regresses and the binary slips past arg
-/// validation into a Manager call, it cannot mutate the real repository
-/// hosting the test suite.
 fn wt(cwd: &std::path::Path) -> assert_cmd::Command {
     let mut cmd = assert_cmd::Command::cargo_bin("wt").expect("wt binary");
     cmd.current_dir(cwd);
@@ -25,9 +8,6 @@ fn sandbox() -> tempfile::TempDir {
     tempfile::TempDir::new().expect("tempdir")
 }
 
-/// `wt create a b c` — three positionals where only two are expected.
-/// Must fail fast with the Usage message, not proceed with `a b` and
-/// ignore `c`.
 #[test]
 fn create_rejects_extra_positional_args() {
     let sb = sandbox();
@@ -36,20 +16,16 @@ fn create_rejects_extra_positional_args() {
         .output()
         .expect("spawn wt");
 
-    assert!(
-        !output.status.success(),
-        "wt create with extra args must exit non-zero"
-    );
+    assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Usage: wt create <branch> <path>"),
-        "expected Usage message, got stderr: {stderr}"
+        "stderr: {stderr}"
     );
 }
 
-/// `wt delete a b` — two positionals where only one is expected.
 #[test]
 fn delete_rejects_extra_positional_args() {
     let sb = sandbox();
@@ -58,20 +34,16 @@ fn delete_rejects_extra_positional_args() {
         .output()
         .expect("spawn wt");
 
-    assert!(
-        !output.status.success(),
-        "wt delete with extra args must exit non-zero"
-    );
+    assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Usage: wt delete <path>"),
-        "expected Usage message, got stderr: {stderr}"
+        "stderr: {stderr}"
     );
 }
 
-/// `wt attach a b` — two positionals where only one is expected.
 #[test]
 fn attach_rejects_extra_positional_args() {
     let sb = sandbox();
@@ -80,23 +52,16 @@ fn attach_rejects_extra_positional_args() {
         .output()
         .expect("spawn wt");
 
-    assert!(
-        !output.status.success(),
-        "wt attach with extra args must exit non-zero"
-    );
+    assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Usage: wt attach <path>"),
-        "expected Usage message, got stderr: {stderr}"
+        "stderr: {stderr}"
     );
 }
 
-/// Scenario from the issue report: an unquoted path with spaces. The
-/// shell would split this into four argv entries; previously the CLI
-/// would silently take the first as the path and proceed. Now it must
-/// reject with the Usage message.
 #[test]
 fn create_rejects_unquoted_path_with_spaces() {
     let sb = sandbox();
@@ -111,26 +76,16 @@ fn create_rejects_unquoted_path_with_spaces() {
         .output()
         .expect("spawn wt");
 
-    assert!(
-        !output.status.success(),
-        "unquoted path with spaces must exit non-zero"
-    );
+    assert!(!output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Usage: wt create <branch> <path>"),
-        "expected Usage message (not a downstream path error), got stderr: {stderr}"
+        "stderr: {stderr}"
     );
-    // The old (buggy) behavior produced "worktree path already exists" or
-    // similar. Make sure we no longer surface that misleading error.
-    assert!(
-        !stderr.contains("already exists"),
-        "must not fall through to a misleading downstream error: {stderr}"
-    );
+    assert!(!stderr.contains("already exists"), "stderr: {stderr}");
 }
 
-/// Missing positional args still trigger the Usage message — the
-/// lower-bound behavior is preserved.
 #[test]
 fn create_rejects_too_few_args() {
     let sb = sandbox();

--- a/iso-code-cli/tests/hook_contract.rs
+++ b/iso-code-cli/tests/hook_contract.rs
@@ -71,8 +71,7 @@ fn hook_claude_code_emits_single_absolute_path_on_stdout() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stdout = String::from_utf8(output.stdout.clone())
-        .expect("stdout must be valid UTF-8");
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout must be valid UTF-8");
     assert!(
         stdout.ends_with('\n'),
         "stdout must be newline-terminated, got {stdout:?}"

--- a/iso-code-mcp/src/main.rs
+++ b/iso-code-mcp/src/main.rs
@@ -41,7 +41,12 @@ struct RpcError {
 
 impl Response {
     fn ok(id: Value, result: Value) -> Self {
-        Self { jsonrpc: "2.0", id, result: Some(result), error: None }
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
     }
 
     fn err(id: Value, code: i32, message: impl Into<String>) -> Self {
@@ -49,7 +54,10 @@ impl Response {
             jsonrpc: "2.0",
             id,
             result: None,
-            error: Some(RpcError { code, message: message.into() }),
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+            }),
         }
     }
 }
@@ -472,18 +480,33 @@ mod tests {
             match name {
                 "worktree_list" | "worktree_status" | "conflict_check" => {
                     assert_eq!(annotations["readOnlyHint"], true, "{name} readOnlyHint");
-                    assert_eq!(annotations["destructiveHint"], false, "{name} destructiveHint");
+                    assert_eq!(
+                        annotations["destructiveHint"], false,
+                        "{name} destructiveHint"
+                    );
                     assert_eq!(annotations["idempotentHint"], true, "{name} idempotentHint");
                 }
                 "worktree_create" => {
                     assert_eq!(annotations["readOnlyHint"], false, "{name} readOnlyHint");
-                    assert_eq!(annotations["destructiveHint"], false, "{name} destructiveHint");
-                    assert_eq!(annotations["idempotentHint"], false, "{name} idempotentHint");
+                    assert_eq!(
+                        annotations["destructiveHint"], false,
+                        "{name} destructiveHint"
+                    );
+                    assert_eq!(
+                        annotations["idempotentHint"], false,
+                        "{name} idempotentHint"
+                    );
                 }
                 "worktree_delete" | "worktree_gc" => {
                     assert_eq!(annotations["readOnlyHint"], false, "{name} readOnlyHint");
-                    assert_eq!(annotations["destructiveHint"], true, "{name} destructiveHint");
-                    assert_eq!(annotations["idempotentHint"], false, "{name} idempotentHint");
+                    assert_eq!(
+                        annotations["destructiveHint"], true,
+                        "{name} destructiveHint"
+                    );
+                    assert_eq!(
+                        annotations["idempotentHint"], false,
+                        "{name} idempotentHint"
+                    );
                 }
                 _ => panic!("unexpected tool: {name}"),
             }

--- a/iso-code-mcp/tests/mcp_contract.rs
+++ b/iso-code-mcp/tests/mcp_contract.rs
@@ -50,7 +50,11 @@ impl McpSession {
         let mut child = cmd.spawn().expect("spawn iso-code-mcp");
         let stdin = child.stdin.take().unwrap();
         let stdout = BufReader::new(child.stdout.take().unwrap());
-        Self { child, stdin, stdout }
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
     }
 
     fn request(&mut self, method: &str, params: Value, id: i64) -> Value {
@@ -64,19 +68,14 @@ impl McpSession {
         self.stdin.flush().expect("flush mcp stdin");
 
         let mut line = String::new();
-        self.stdout
-            .read_line(&mut line)
-            .expect("read mcp response");
+        self.stdout.read_line(&mut line).expect("read mcp response");
         assert!(!line.trim().is_empty(), "empty mcp response");
-        serde_json::from_str(&line).unwrap_or_else(|e| panic!("bad JSON-RPC response {line:?}: {e}"))
+        serde_json::from_str(&line)
+            .unwrap_or_else(|e| panic!("bad JSON-RPC response {line:?}: {e}"))
     }
 
     fn tools_call(&mut self, tool: &str, args: Value, id: i64) -> Value {
-        self.request(
-            "tools/call",
-            json!({ "name": tool, "arguments": args }),
-            id,
-        )
+        self.request("tools/call", json!({ "name": tool, "arguments": args }), id)
     }
 
     fn shutdown(mut self) {
@@ -221,7 +220,9 @@ fn qa_m_004_worktree_create() {
     let payload = content_payload(&resp);
     assert_eq!(payload["branch"], "mcp-create-branch");
     assert_eq!(payload["state"], "Active");
-    assert!(payload["session_uuid"].as_str().is_some_and(|s| !s.is_empty()));
+    assert!(payload["session_uuid"]
+        .as_str()
+        .is_some_and(|s| !s.is_empty()));
     assert!(wt_path.exists(), "worktree dir must be created on disk");
 
     s.shutdown();

--- a/iso-code/examples/custom_config.rs
+++ b/iso-code/examples/custom_config.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create with options
     let mut opts = CreateOptions::default();
     opts.base = Some("main".to_string()); // branch from main instead of HEAD
-    opts.lock = true;                     // lock immediately after creation
+    opts.lock = true; // lock immediately after creation
     opts.lock_reason = Some("automated test run".to_string());
     opts.reflink_mode = ReflinkMode::Preferred;
     opts.allocate_port = true;

--- a/iso-code/src/adapter.rs
+++ b/iso-code/src/adapter.rs
@@ -227,8 +227,7 @@ mod tests {
             port: String::new(),
             uuid: "u".to_string(),
         };
-        let m: std::collections::HashMap<&str, &str> =
-            env.as_pairs().into_iter().collect();
+        let m: std::collections::HashMap<&str, &str> = env.as_pairs().into_iter().collect();
         assert_eq!(m["CCMANAGER_WORKTREE_PATH"], m["ISO_CODE_PATH"]);
         assert_eq!(m["CCMANAGER_BRANCH_NAME"], m["ISO_CODE_BRANCH"]);
         assert_eq!(m["CCMANAGER_GIT_ROOT"], m["ISO_CODE_REPO"]);

--- a/iso-code/src/adapters/default.rs
+++ b/iso-code/src/adapters/default.rs
@@ -92,7 +92,9 @@ impl EcosystemAdapter for DefaultAdapter {
             // re-applying here is idempotent and keeps behavior uniform.
             #[cfg(unix)]
             {
-                let perms = std::fs::metadata(&src).map_err(WorktreeError::Io)?.permissions();
+                let perms = std::fs::metadata(&src)
+                    .map_err(WorktreeError::Io)?
+                    .permissions();
                 std::fs::set_permissions(&dst, perms).map_err(WorktreeError::Io)?;
             }
         }
@@ -142,10 +144,7 @@ mod tests {
     fn setup_skips_missing_source_without_error() {
         let (src, dst) = make_pair();
         // No files in src.
-        let adapter = DefaultAdapter::new(vec![
-            PathBuf::from(".env"),
-            PathBuf::from(".env.local"),
-        ]);
+        let adapter = DefaultAdapter::new(vec![PathBuf::from(".env"), PathBuf::from(".env.local")]);
 
         adapter
             .setup(dst.path(), src.path(), &SetupContext::default())
@@ -174,10 +173,7 @@ mod tests {
     #[test]
     fn detect_returns_false_when_no_files_exist() {
         let src = TempDir::new().unwrap();
-        let adapter = DefaultAdapter::new(vec![
-            PathBuf::from(".env"),
-            PathBuf::from(".env.local"),
-        ]);
+        let adapter = DefaultAdapter::new(vec![PathBuf::from(".env"), PathBuf::from(".env.local")]);
         assert!(!adapter.detect(src.path()));
     }
 
@@ -187,8 +183,8 @@ mod tests {
         fs::write(src.path().join(".env.local"), "").unwrap();
 
         let adapter = DefaultAdapter::new(vec![
-            PathBuf::from(".env"),         // missing
-            PathBuf::from(".env.local"),   // present
+            PathBuf::from(".env"),       // missing
+            PathBuf::from(".env.local"), // present
         ]);
         assert!(adapter.detect(src.path()));
     }
@@ -233,10 +229,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            fs::read_to_string(dst.path().join(".env")).unwrap(),
-            "x=1"
-        );
+        assert_eq!(fs::read_to_string(dst.path().join(".env")).unwrap(), "x=1");
     }
 
     #[cfg(unix)]

--- a/iso-code/src/error.rs
+++ b/iso-code/src/error.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use crate::types::WorktreeState;
+use std::path::PathBuf;
 
 /// Errors returned by iso-code operations.
 #[derive(Debug, thiserror::Error)]

--- a/iso-code/src/git.rs
+++ b/iso-code/src/git.rs
@@ -12,14 +12,13 @@ use crate::types::{GitCapabilities, GitVersion, WorktreeHandle, WorktreeState};
 /// - "git version 2.43.0.windows.1"
 pub fn parse_git_version(output: &str) -> Result<GitVersion, WorktreeError> {
     // Extract the version string after "git version "
-    let version_str = output
-        .trim()
-        .strip_prefix("git version ")
-        .ok_or_else(|| WorktreeError::GitCommandFailed {
+    let version_str = output.trim().strip_prefix("git version ").ok_or_else(|| {
+        WorktreeError::GitCommandFailed {
             command: "git --version".to_string(),
             stderr: format!("unexpected output format: {output}"),
             exit_code: 0,
-        })?;
+        }
+    })?;
 
     // Take the first space-delimited token (drops "(Apple Git-146)" suffix)
     let version_token = version_str.split_whitespace().next().unwrap_or(version_str);
@@ -34,32 +33,52 @@ pub fn parse_git_version(output: &str) -> Result<GitVersion, WorktreeError> {
         });
     }
 
-    let major = parts[0].parse::<u32>().map_err(|_| WorktreeError::GitCommandFailed {
-        command: "git --version".to_string(),
-        stderr: format!("cannot parse major version: {}", parts[0]),
-        exit_code: 0,
-    })?;
-    let minor = parts[1].parse::<u32>().map_err(|_| WorktreeError::GitCommandFailed {
-        command: "git --version".to_string(),
-        stderr: format!("cannot parse minor version: {}", parts[1]),
-        exit_code: 0,
-    })?;
-    let patch = parts[2].parse::<u32>().map_err(|_| WorktreeError::GitCommandFailed {
-        command: "git --version".to_string(),
-        stderr: format!("cannot parse patch version: {}", parts[2]),
-        exit_code: 0,
-    })?;
+    let major = parts[0]
+        .parse::<u32>()
+        .map_err(|_| WorktreeError::GitCommandFailed {
+            command: "git --version".to_string(),
+            stderr: format!("cannot parse major version: {}", parts[0]),
+            exit_code: 0,
+        })?;
+    let minor = parts[1]
+        .parse::<u32>()
+        .map_err(|_| WorktreeError::GitCommandFailed {
+            command: "git --version".to_string(),
+            stderr: format!("cannot parse minor version: {}", parts[1]),
+            exit_code: 0,
+        })?;
+    let patch = parts[2]
+        .parse::<u32>()
+        .map_err(|_| WorktreeError::GitCommandFailed {
+            command: "git --version".to_string(),
+            stderr: format!("cannot parse patch version: {}", parts[2]),
+            exit_code: 0,
+        })?;
 
-    Ok(GitVersion { major, minor, patch })
+    Ok(GitVersion {
+        major,
+        minor,
+        patch,
+    })
 }
 
 /// Build a `GitCapabilities` struct from a detected `GitVersion`.
 pub fn detect_capabilities(version: &GitVersion) -> GitCapabilities {
-    let has_repair = *version >= GitVersion::HAS_REPAIR;               // 2.30+
-    let has_list_nul = *version >= GitVersion::HAS_LIST_NUL;           // 2.36+
+    let has_repair = *version >= GitVersion::HAS_REPAIR; // 2.30+
+    let has_list_nul = *version >= GitVersion::HAS_LIST_NUL; // 2.36+
     let has_merge_tree_write = *version >= GitVersion::HAS_MERGE_TREE_WRITE; // 2.38+
-    let has_orphan = *version >= GitVersion { major: 2, minor: 42, patch: 0 }; // 2.42+
-    let has_relative_paths = *version >= GitVersion { major: 2, minor: 48, patch: 0 }; // 2.48+
+    let has_orphan = *version
+        >= GitVersion {
+            major: 2,
+            minor: 42,
+            patch: 0,
+        }; // 2.42+
+    let has_relative_paths = *version
+        >= GitVersion {
+            major: 2,
+            minor: 48,
+            patch: 0,
+        }; // 2.48+
 
     GitCapabilities::new(
         version.clone(),
@@ -152,10 +171,7 @@ pub fn parse_worktree_list_porcelain(
                 head_sha = String::from_utf8_lossy(sha).into_owned();
             } else if let Some(b) = strip_prefix_bytes(field, b"branch ") {
                 let s = String::from_utf8_lossy(b);
-                branch = s
-                    .strip_prefix("refs/heads/")
-                    .unwrap_or(&s)
-                    .to_string();
+                branch = s.strip_prefix("refs/heads/").unwrap_or(&s).to_string();
             } else if field == b"detached" {
                 is_detached = true;
             } else if field == b"bare" {
@@ -288,7 +304,10 @@ pub fn run_worktree_list(
 
     if !output.status.success() {
         return Err(WorktreeError::GitCommandFailed {
-            command: format!("git worktree list --porcelain{}", if caps.has_list_nul { " -z" } else { "" }),
+            command: format!(
+                "git worktree list --porcelain{}",
+                if caps.has_list_nul { " -z" } else { "" }
+            ),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
             exit_code: output.status.code().unwrap_or(-1),
         });
@@ -483,25 +502,53 @@ mod tests {
     #[test]
     fn parse_standard_version() {
         let v = parse_git_version("git version 2.43.0").unwrap();
-        assert_eq!(v, GitVersion { major: 2, minor: 43, patch: 0 });
+        assert_eq!(
+            v,
+            GitVersion {
+                major: 2,
+                minor: 43,
+                patch: 0
+            }
+        );
     }
 
     #[test]
     fn parse_apple_version() {
         let v = parse_git_version("git version 2.39.3 (Apple Git-146)").unwrap();
-        assert_eq!(v, GitVersion { major: 2, minor: 39, patch: 3 });
+        assert_eq!(
+            v,
+            GitVersion {
+                major: 2,
+                minor: 39,
+                patch: 3
+            }
+        );
     }
 
     #[test]
     fn parse_windows_version() {
         let v = parse_git_version("git version 2.43.0.windows.1").unwrap();
-        assert_eq!(v, GitVersion { major: 2, minor: 43, patch: 0 });
+        assert_eq!(
+            v,
+            GitVersion {
+                major: 2,
+                minor: 43,
+                patch: 0
+            }
+        );
     }
 
     #[test]
     fn parse_with_trailing_newline() {
         let v = parse_git_version("git version 2.20.0\n").unwrap();
-        assert_eq!(v, GitVersion { major: 2, minor: 20, patch: 0 });
+        assert_eq!(
+            v,
+            GitVersion {
+                major: 2,
+                minor: 20,
+                patch: 0
+            }
+        );
     }
 
     #[test]
@@ -513,13 +560,21 @@ mod tests {
 
     #[test]
     fn version_2_19_is_too_old() {
-        let v = GitVersion { major: 2, minor: 19, patch: 9 };
+        let v = GitVersion {
+            major: 2,
+            minor: 19,
+            patch: 9,
+        };
         assert!(v < GitVersion::MINIMUM);
     }
 
     #[test]
     fn version_2_20_is_ok() {
-        let v = GitVersion { major: 2, minor: 20, patch: 0 };
+        let v = GitVersion {
+            major: 2,
+            minor: 20,
+            patch: 0,
+        };
         assert!(v >= GitVersion::MINIMUM);
     }
 
@@ -527,7 +582,11 @@ mod tests {
 
     #[test]
     fn capabilities_at_2_20() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 20, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 20,
+            patch: 0,
+        });
         assert!(!caps.has_repair);
         assert!(!caps.has_list_nul);
         assert!(!caps.has_merge_tree_write);
@@ -537,27 +596,43 @@ mod tests {
 
     #[test]
     fn capabilities_at_2_29_no_repair() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 29, patch: 9 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 29,
+            patch: 9,
+        });
         assert!(!caps.has_repair);
     }
 
     #[test]
     fn capabilities_at_2_30_has_repair() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 30, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 30,
+            patch: 0,
+        });
         assert!(caps.has_repair);
         assert!(!caps.has_list_nul);
     }
 
     #[test]
     fn capabilities_at_2_35_no_list_nul() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 35, patch: 9 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 35,
+            patch: 9,
+        });
         assert!(caps.has_repair);
         assert!(!caps.has_list_nul);
     }
 
     #[test]
     fn capabilities_at_2_36_has_list_nul() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 36, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 36,
+            patch: 0,
+        });
         assert!(caps.has_repair);
         assert!(caps.has_list_nul);
         assert!(!caps.has_merge_tree_write);
@@ -565,21 +640,33 @@ mod tests {
 
     #[test]
     fn capabilities_at_2_38_has_merge_tree() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 38, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 38,
+            patch: 0,
+        });
         assert!(caps.has_merge_tree_write);
         assert!(!caps.has_orphan);
     }
 
     #[test]
     fn capabilities_at_2_42_has_orphan() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 42, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 42,
+            patch: 0,
+        });
         assert!(caps.has_orphan);
         assert!(!caps.has_relative_paths);
     }
 
     #[test]
     fn capabilities_at_2_48_has_relative_paths() {
-        let caps = detect_capabilities(&GitVersion { major: 2, minor: 48, patch: 0 });
+        let caps = detect_capabilities(&GitVersion {
+            major: 2,
+            minor: 48,
+            patch: 0,
+        });
         assert!(caps.has_relative_paths);
         // All other caps should be true too
         assert!(caps.has_repair);
@@ -609,9 +696,15 @@ mod tests {
         let output = b"worktree /home/user/project\nHEAD abc1234abc1234abc1234abc1234abc1234abc1234\nbranch refs/heads/main\n\n";
         let result = parse_worktree_list_porcelain(output, false).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, std::path::PathBuf::from("/home/user/project"));
+        assert_eq!(
+            result[0].path,
+            std::path::PathBuf::from("/home/user/project")
+        );
         assert_eq!(result[0].branch, "main");
-        assert_eq!(result[0].base_commit, "abc1234abc1234abc1234abc1234abc1234abc1234");
+        assert_eq!(
+            result[0].base_commit,
+            "abc1234abc1234abc1234abc1234abc1234abc1234"
+        );
         assert_eq!(result[0].state, WorktreeState::Active);
     }
 
@@ -674,7 +767,10 @@ mod tests {
         let output = b"worktree /home/user/my project\0HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0branch refs/heads/main\0\0";
         let result = parse_worktree_list_porcelain(output, true).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, std::path::PathBuf::from("/home/user/my project"));
+        assert_eq!(
+            result[0].path,
+            std::path::PathBuf::from("/home/user/my project")
+        );
     }
 
     #[cfg(unix)]
@@ -684,7 +780,9 @@ mod tests {
         let mut output: Vec<u8> = Vec::new();
         output.extend_from_slice(b"worktree /tmp/wt-");
         output.push(0xff);
-        output.extend_from_slice(b"-end\0HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0branch refs/heads/x\0\0");
+        output.extend_from_slice(
+            b"-end\0HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0branch refs/heads/x\0\0",
+        );
 
         let result = parse_worktree_list_porcelain(&output, true).unwrap();
         assert_eq!(result.len(), 1);

--- a/iso-code/src/guards.rs
+++ b/iso-code/src/guards.rs
@@ -40,10 +40,7 @@ pub(crate) fn check_disk_space(target_path: &Path, required_mb: u64) -> Result<(
         target_path.to_path_buf()
     } else {
         // If target doesn't exist yet, check parent
-        target_path
-            .parent()
-            .unwrap_or(Path::new("/"))
-            .to_path_buf()
+        target_path.parent().unwrap_or(Path::new("/")).to_path_buf()
     };
 
     let disks = Disks::new_with_refreshed_list();
@@ -154,16 +151,13 @@ pub(crate) fn check_not_network_filesystem(path: &Path) -> Result<(), WorktreeEr
     // Platform-specific detection
     #[cfg(target_os = "macos")]
     {
-        let path_cstr = std::ffi::CString::new(
-            path.to_str().unwrap_or("/"),
-        )
-        .unwrap_or_else(|_| std::ffi::CString::new("/").unwrap());
+        let path_cstr = std::ffi::CString::new(path.to_str().unwrap_or("/"))
+            .unwrap_or_else(|_| std::ffi::CString::new("/").unwrap());
 
         unsafe {
             let mut stat: libc::statfs = std::mem::zeroed();
             if libc::statfs(path_cstr.as_ptr(), &mut stat) == 0 {
-                let fstype = std::ffi::CStr::from_ptr(stat.f_fstypename.as_ptr())
-                    .to_string_lossy();
+                let fstype = std::ffi::CStr::from_ptr(stat.f_fstypename.as_ptr()).to_string_lossy();
                 let network_types = ["nfs", "smbfs", "afpfs", "cifs", "webdav"];
                 if network_types.iter().any(|t| fstype.eq_ignore_ascii_case(t)) {
                     return Err(WorktreeError::NetworkFilesystem {
@@ -185,9 +179,7 @@ pub(crate) fn check_not_network_filesystem(path: &Path) -> Result<(), WorktreeEr
                 if parts.len() >= 3 {
                     let mount_point = parts[1];
                     let fs_type = parts[2];
-                    if path_str.starts_with(mount_point)
-                        && network_types.contains(&fs_type)
-                    {
+                    if path_str.starts_with(mount_point) && network_types.contains(&fs_type) {
                         return Err(WorktreeError::NetworkFilesystem {
                             mount_point: std::path::PathBuf::from(mount_point),
                         });
@@ -277,7 +269,8 @@ pub(crate) fn check_total_disk_usage(
         return Ok(());
     }
 
-    let total_bytes = crate::util::dir_size_skipping_git(worktrees.iter().map(|wt| wt.path.as_path()));
+    let total_bytes =
+        crate::util::dir_size_skipping_git(worktrees.iter().map(|wt| wt.path.as_path()));
 
     if let Some(limit) = max_bytes {
         if total_bytes > limit {
@@ -379,7 +372,6 @@ pub(crate) fn check_git_crypt_pre_create(repo: &Path) -> Result<GitCryptStatus, 
     Ok(GitCryptStatus::Unlocked)
 }
 
-
 /// Arguments for `run_pre_create_guards`. Keeps the guard runner readable
 /// and maps directly onto Config / CreateOptions fields so wiring new knobs
 /// doesn't require touching every call site.
@@ -401,7 +393,9 @@ pub(crate) struct PreCreateArgs<'a> {
 /// Run every pre-create guard in order. The ordering is load-bearing: later
 /// guards assume invariants established by earlier ones. Returns the detected
 /// [`GitCryptStatus`] so callers can decide whether to proceed.
-pub(crate) fn run_pre_create_guards(args: PreCreateArgs<'_>) -> Result<GitCryptStatus, WorktreeError> {
+pub(crate) fn run_pre_create_guards(
+    args: PreCreateArgs<'_>,
+) -> Result<GitCryptStatus, WorktreeError> {
     // 1. Branch not already checked out
     check_branch_not_checked_out(args.repo, args.branch, args.caps)?;
 
@@ -635,7 +629,9 @@ pub(crate) fn five_step_unmerged_check(
         if let Ok(out) = step4 {
             if out.status.success() {
                 let stdout = String::from_utf8_lossy(&out.stdout);
-                let has_plus_lines = stdout.lines().any(|l| l.starts_with("+ ") || l.starts_with('+'));
+                let has_plus_lines = stdout
+                    .lines()
+                    .any(|l| l.starts_with("+ ") || l.starts_with('+'));
                 if !has_plus_lines {
                     // All patches are upstream (only '-' lines or empty)
                     return Ok(());
@@ -697,7 +693,10 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            WorktreeError::RateLimitExceeded { current: 20, max: 20 }
+            WorktreeError::RateLimitExceeded {
+                current: 20,
+                max: 20
+            }
         ));
     }
 
@@ -714,13 +713,17 @@ mod tests {
         let path = PathBuf::from("/tmp");
         let result = check_path_not_exists(&path);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), WorktreeError::WorktreePathExists(_)));
+        assert!(matches!(
+            result.unwrap_err(),
+            WorktreeError::WorktreePathExists(_)
+        ));
     }
 
     /// QA-G-005: empty worktree list → nested check trivially passes.
     #[test]
     fn test_check_not_nested_no_worktrees() {
-        let result = check_not_nested_worktree(Path::new("/tmp/test"), Path::new("/some/repo"), &[]);
+        let result =
+            check_not_nested_worktree(Path::new("/tmp/test"), Path::new("/some/repo"), &[]);
         assert!(result.is_ok());
     }
 
@@ -744,7 +747,8 @@ mod tests {
         )];
         let candidate = base.join("nested").join("wt");
         // Use a repo_root that differs from the existing worktree so it's not skipped
-        let result = check_not_nested_worktree(&candidate, Path::new("/some/other/repo"), &existing);
+        let result =
+            check_not_nested_worktree(&candidate, Path::new("/some/other/repo"), &existing);
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -784,7 +788,10 @@ mod tests {
         // 999 TB requirement should fail
         let result = check_disk_space(Path::new("/tmp"), 999_000_000);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), WorktreeError::DiskSpaceLow { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            WorktreeError::DiskSpaceLow { .. }
+        ));
     }
 
     /// QA-G-012: repository without git-crypt returns NotUsed.
@@ -837,7 +844,10 @@ mod tests {
         );
         let result = check_not_locked(&handle);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), WorktreeError::WorktreeLocked { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            WorktreeError::WorktreeLocked { .. }
+        ));
     }
 
     /// QA-G-010: with no max_bytes and no threshold, the aggregate-disk check passes trivially.

--- a/iso-code/src/lock.rs
+++ b/iso-code/src/lock.rs
@@ -48,10 +48,7 @@ impl StateLock {
     /// We never unlink the lock file during acquisition — that would create
     /// a two-inode race where two processes each hold flock on a different
     /// inode.
-    pub fn acquire(
-        lock_path: &Path,
-        timeout_ms: u64,
-    ) -> Result<Self, WorktreeError> {
+    pub fn acquire(lock_path: &Path, timeout_ms: u64) -> Result<Self, WorktreeError> {
         // Ensure parent directory exists
         if let Some(parent) = lock_path.parent() {
             fs::create_dir_all(parent)?;
@@ -244,8 +241,7 @@ fn is_network_filesystem(path: &Path) -> bool {
         unsafe {
             let mut stat: libc::statfs = std::mem::zeroed();
             if libc::statfs(path_cstr.as_ptr(), &mut stat) == 0 {
-                let fstype = std::ffi::CStr::from_ptr(stat.f_fstypename.as_ptr())
-                    .to_string_lossy();
+                let fstype = std::ffi::CStr::from_ptr(stat.f_fstypename.as_ptr()).to_string_lossy();
                 let network_types = ["nfs", "smbfs", "afpfs", "cifs", "webdav"];
                 return network_types.iter().any(|t| fstype.eq_ignore_ascii_case(t));
             }

--- a/iso-code/src/manager.rs
+++ b/iso-code/src/manager.rs
@@ -1912,7 +1912,12 @@ mod tests {
         fn detect(&self, _worktree_path: &Path) -> bool {
             true
         }
-        fn setup(&self, _worktree_path: &Path, _source: &Path, _ctx: &SetupContext) -> Result<(), WorktreeError> {
+        fn setup(
+            &self,
+            _worktree_path: &Path,
+            _source: &Path,
+            _ctx: &SetupContext,
+        ) -> Result<(), WorktreeError> {
             Ok(())
         }
         fn teardown(&self, _worktree_path: &Path) -> Result<(), WorktreeError> {
@@ -2044,7 +2049,12 @@ mod tests {
         fn detect(&self, _worktree_path: &Path) -> bool {
             true
         }
-        fn setup(&self, _worktree_path: &Path, _source: &Path, _ctx: &SetupContext) -> Result<(), WorktreeError> {
+        fn setup(
+            &self,
+            _worktree_path: &Path,
+            _source: &Path,
+            _ctx: &SetupContext,
+        ) -> Result<(), WorktreeError> {
             let mut map = self.captured.lock().unwrap();
             for key in [
                 "ISO_CODE_PATH",
@@ -2141,7 +2151,12 @@ mod tests {
         fn detect(&self, _worktree_path: &Path) -> bool {
             true
         }
-        fn setup(&self, _worktree_path: &Path, _source: &Path, _ctx: &SetupContext) -> Result<(), WorktreeError> {
+        fn setup(
+            &self,
+            _worktree_path: &Path,
+            _source: &Path,
+            _ctx: &SetupContext,
+        ) -> Result<(), WorktreeError> {
             Err(WorktreeError::StateCorrupted {
                 reason: "synthetic setup failure".to_string(),
             })
@@ -2166,7 +2181,12 @@ mod tests {
             self.log.lock().unwrap().push("detect".to_string());
             true
         }
-        fn setup(&self, _worktree_path: &Path, _source: &Path, _ctx: &SetupContext) -> Result<(), WorktreeError> {
+        fn setup(
+            &self,
+            _worktree_path: &Path,
+            _source: &Path,
+            _ctx: &SetupContext,
+        ) -> Result<(), WorktreeError> {
             self.log.lock().unwrap().push("setup".to_string());
             Ok(())
         }
@@ -2299,5 +2319,4 @@ mod tests {
             "git worktree registry must not retain the branch after setup() failure"
         );
     }
-
 }

--- a/iso-code/src/platform/mod.rs
+++ b/iso-code/src/platform/mod.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use crate::error::WorktreeError;
 use crate::types::{CopyOutcome, ReflinkMode};
 
-#[cfg(target_os = "macos")]
-mod macos;
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
 #[cfg(target_os = "windows")]
 mod windows;
 
@@ -17,11 +17,7 @@ mod windows;
 /// - `Disabled`: always use standard copy.
 ///
 /// Returns the `CopyOutcome` describing what actually happened.
-pub fn copy_file(
-    src: &Path,
-    dst: &Path,
-    mode: ReflinkMode,
-) -> Result<CopyOutcome, WorktreeError> {
+pub fn copy_file(src: &Path, dst: &Path, mode: ReflinkMode) -> Result<CopyOutcome, WorktreeError> {
     match mode {
         ReflinkMode::Required => {
             reflink_copy::reflink(src, dst).map_err(|_| WorktreeError::ReflinkNotSupported)?;

--- a/iso-code/src/ports.rs
+++ b/iso-code/src/ports.rs
@@ -46,10 +46,7 @@ pub fn allocate_port(
 ) -> Result<u16, WorktreeError> {
     let range_size = (port_range_end - port_range_start) as u32;
     if range_size == 0 {
-        return Err(WorktreeError::RateLimitExceeded {
-            current: 0,
-            max: 0,
-        });
+        return Err(WorktreeError::RateLimitExceeded { current: 0, max: 0 });
     }
 
     let now = chrono::Utc::now();
@@ -79,12 +76,7 @@ pub fn allocate_port(
 }
 
 /// Build a PortLease with 8-hour TTL.
-pub fn make_lease(
-    port: u16,
-    branch: &str,
-    session_uuid: &str,
-    pid: u32,
-) -> PortLease {
+pub fn make_lease(port: u16, branch: &str, session_uuid: &str, pid: u32) -> PortLease {
     let now = chrono::Utc::now();
     PortLease {
         port,

--- a/iso-code/src/state.rs
+++ b/iso-code/src/state.rs
@@ -112,12 +112,24 @@ pub struct ConfigSnapshot {
     pub extra: HashMap<String, Value>,
 }
 
-fn default_max_worktrees() -> usize { 20 }
-fn default_disk_threshold() -> u8 { 90 }
-fn default_gc_max_age() -> u32 { 7 }
-fn default_port_start() -> u16 { 3100 }
-fn default_port_end() -> u16 { 5100 }
-fn default_stale_ttl() -> u32 { 30 }
+fn default_max_worktrees() -> usize {
+    20
+}
+fn default_disk_threshold() -> u8 {
+    90
+}
+fn default_gc_max_age() -> u32 {
+    7
+}
+fn default_port_start() -> u16 {
+    3100
+}
+fn default_port_end() -> u16 {
+    5100
+}
+fn default_stale_ttl() -> u32 {
+    30
+}
 
 /// A single GC history record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -159,8 +171,7 @@ impl StateV2 {
 /// Compute the repo_id: sha256 hex of the absolute canonicalized repo path.
 pub fn compute_repo_id(repo_root: &Path) -> String {
     use sha2::{Digest, Sha256};
-    let canonical = dunce::canonicalize(repo_root)
-        .unwrap_or_else(|_| repo_root.to_path_buf());
+    let canonical = dunce::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
     let mut hasher = Sha256::new();
     hasher.update(canonical.to_string_lossy().as_bytes());
     format!("{:x}", hasher.finalize())
@@ -190,7 +201,10 @@ pub fn state_lock_path(repo_root: &Path, home_override: Option<&Path>) -> PathBu
 }
 
 /// Ensure the state directory exists. Called from Manager::new().
-pub fn ensure_state_dir(repo_root: &Path, home_override: Option<&Path>) -> Result<(), WorktreeError> {
+pub fn ensure_state_dir(
+    repo_root: &Path,
+    home_override: Option<&Path>,
+) -> Result<(), WorktreeError> {
     let dir = state_dir(repo_root, home_override);
     fs::create_dir_all(&dir)?;
     Ok(())
@@ -206,7 +220,10 @@ pub fn ensure_state_dir(repo_root: &Path, home_override: Option<&Path>) -> Resul
 /// returned. The next `list()` will repopulate active worktrees from
 /// `git worktree list`. A migration failure (unknown schema version) is
 /// surfaced as `StateCorrupted` — we don't clobber data we can't interpret.
-pub fn read_state(repo_root: &Path, home_override: Option<&Path>) -> Result<StateV2, WorktreeError> {
+pub fn read_state(
+    repo_root: &Path,
+    home_override: Option<&Path>,
+) -> Result<StateV2, WorktreeError> {
     let path = state_json_path(repo_root, home_override);
 
     if !path.exists() {
@@ -251,10 +268,8 @@ pub fn write_state(
     // Update last_modified timestamp
     state.last_modified = Utc::now();
 
-    let json = serde_json::to_string_pretty(state).map_err(|e| {
-        WorktreeError::StateCorrupted {
-            reason: format!("serialization failed: {e}"),
-        }
+    let json = serde_json::to_string_pretty(state).map_err(|e| WorktreeError::StateCorrupted {
+        reason: format!("serialization failed: {e}"),
     })?;
 
     // Write to tmp file
@@ -273,7 +288,8 @@ pub fn write_state(
 /// Schema migration dispatcher. Upgrades older state files to the current
 /// schema version in-place before they are returned to callers.
 pub fn migrate(raw: Value) -> Result<StateV2, WorktreeError> {
-    let version = raw.get("schema_version")
+    let version = raw
+        .get("schema_version")
         .and_then(|v| v.as_u64())
         .or_else(|| raw.get("version").and_then(|v| v.as_u64()))
         .unwrap_or(1);
@@ -293,7 +309,8 @@ pub fn migrate(raw: Value) -> Result<StateV2, WorktreeError> {
 ///
 /// v1 format: `{ "version": 1, "worktrees": { ... } }`.
 fn migrate_v1_to_v2(raw: Value) -> Result<StateV2, WorktreeError> {
-    let repo_id = raw.get("repo_id")
+    let repo_id = raw
+        .get("repo_id")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
@@ -304,8 +321,8 @@ fn migrate_v1_to_v2(raw: Value) -> Result<StateV2, WorktreeError> {
     let mut active_worktrees = HashMap::new();
     if let Some(wts) = raw.get("worktrees").and_then(|v| v.as_object()) {
         for (key, val) in wts {
-            let entry: ActiveWorktreeEntry = serde_json::from_value(val.clone())
-                .map_err(|e| WorktreeError::StateCorrupted {
+            let entry: ActiveWorktreeEntry =
+                serde_json::from_value(val.clone()).map_err(|e| WorktreeError::StateCorrupted {
                     reason: format!("v1 worktree entry '{key}' invalid: {e}"),
                 })?;
             active_worktrees.insert(key.clone(), entry);
@@ -503,7 +520,10 @@ mod tests {
         }"#;
 
         let state: StateV2 = serde_json::from_str(json).unwrap();
-        assert_eq!(state.extra.get("future_field").unwrap(), "hello from the future");
+        assert_eq!(
+            state.extra.get("future_field").unwrap(),
+            "hello from the future"
+        );
         assert_eq!(state.extra.get("another_unknown").unwrap(), 42);
 
         // Re-serialize and verify unknown fields survive

--- a/iso-code/src/types.rs
+++ b/iso-code/src/types.rs
@@ -142,7 +142,9 @@ pub enum ReflinkMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CopyOutcome {
     Reflinked,
-    StandardCopy { bytes_written: u64 },
+    StandardCopy {
+        bytes_written: u64,
+    },
     /// No file copying occurred (worktree created via git checkout only).
     None,
 }
@@ -313,7 +315,13 @@ impl GcReport {
         freed_bytes: u64,
         dry_run: bool,
     ) -> Self {
-        Self { orphans, removed, evicted, freed_bytes, dry_run }
+        Self {
+            orphans,
+            removed,
+            evicted,
+            freed_bytes,
+            dry_run,
+        }
     }
 }
 
@@ -347,7 +355,14 @@ impl GitCapabilities {
         has_relative_paths: bool,
         has_merge_tree_write: bool,
     ) -> Self {
-        Self { version, has_list_nul, has_repair, has_orphan, has_relative_paths, has_merge_tree_write }
+        Self {
+            version,
+            has_list_nul,
+            has_repair,
+            has_orphan,
+            has_relative_paths,
+            has_merge_tree_write,
+        }
     }
 }
 
@@ -360,10 +375,26 @@ pub struct GitVersion {
 }
 
 impl GitVersion {
-    pub const MINIMUM: GitVersion = GitVersion { major: 2, minor: 20, patch: 0 };
-    pub const HAS_LIST_NUL: GitVersion = GitVersion { major: 2, minor: 36, patch: 0 };
-    pub const HAS_REPAIR: GitVersion = GitVersion { major: 2, minor: 30, patch: 0 };
-    pub const HAS_MERGE_TREE_WRITE: GitVersion = GitVersion { major: 2, minor: 38, patch: 0 };
+    pub const MINIMUM: GitVersion = GitVersion {
+        major: 2,
+        minor: 20,
+        patch: 0,
+    };
+    pub const HAS_LIST_NUL: GitVersion = GitVersion {
+        major: 2,
+        minor: 36,
+        patch: 0,
+    };
+    pub const HAS_REPAIR: GitVersion = GitVersion {
+        major: 2,
+        minor: 30,
+        patch: 0,
+    };
+    pub const HAS_MERGE_TREE_WRITE: GitVersion = GitVersion {
+        major: 2,
+        minor: 38,
+        patch: 0,
+    };
 }
 
 // ── 4.9 PortLease ───────────────────────────────────────────────────────

--- a/iso-code/src/util.rs
+++ b/iso-code/src/util.rs
@@ -11,8 +11,7 @@ use std::path::Path;
 pub fn dir_size_skipping_git<'a, I: IntoIterator<Item = &'a Path>>(roots: I) -> u64 {
     let mut total: u64 = 0;
     #[cfg(unix)]
-    let mut seen_inodes: std::collections::HashSet<(u64, u64)> =
-        std::collections::HashSet::new();
+    let mut seen_inodes: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();
 
     for root in roots {
         if !root.exists() {
@@ -39,8 +38,8 @@ pub fn dir_size_skipping_git<'a, I: IntoIterator<Item = &'a Path>>(roots: I) -> 
                             continue;
                         }
                     }
-                    total += filesize::file_real_size_fast(entry.path(), &meta)
-                        .unwrap_or(meta.len());
+                    total +=
+                        filesize::file_real_size_fast(entry.path(), &meta).unwrap_or(meta.len());
                 }
             }
         }

--- a/iso-code/tests/concurrency.rs
+++ b/iso-code/tests/concurrency.rs
@@ -213,7 +213,9 @@ fn qa_c_004_circuit_breaker_trips_after_consecutive_failures() {
     for i in 0..6 {
         match mgr.list() {
             Ok(_) => {}
-            Err(WorktreeError::CircuitBreakerOpen { consecutive_failures }) => {
+            Err(WorktreeError::CircuitBreakerOpen {
+                consecutive_failures,
+            }) => {
                 assert!(
                     consecutive_failures >= 3,
                     "breaker should trip at or after threshold, got {consecutive_failures} on attempt {i}"
@@ -354,7 +356,8 @@ fn qa_c_008_pid_reuse_false_positive_detected() {
     let start = Instant::now();
     let mgr = Manager::new(repo.path(), Config::default())
         .expect("Manager::new() should tolerate stale lock payload");
-    mgr.list().expect("list should succeed despite stale payload");
+    mgr.list()
+        .expect("list should succeed despite stale payload");
     assert!(
         start.elapsed() < Duration::from_secs(5),
         "stale payload should not cause lock-acquisition timeout"

--- a/iso-code/tests/guards_matrix.rs
+++ b/iso-code/tests/guards_matrix.rs
@@ -23,7 +23,11 @@ fn qa_g_001_branch_already_checked_out() {
     let mgr = Manager::new(repo.path(), Config::default()).unwrap();
 
     let (h1, _) = mgr
-        .create("feature-x", repo.path().join("wt-1"), CreateOptions::default())
+        .create(
+            "feature-x",
+            repo.path().join("wt-1"),
+            CreateOptions::default(),
+        )
         .unwrap();
     let result = mgr.create(
         "feature-x",
@@ -153,7 +157,10 @@ fn qa_g_008_bare_repo_permitted() {
     // Bare repos have no HEAD until a branch exists — create a minimal
     // source commit via a temp worktree so `resolve_ref("HEAD")` works.
     let seed = repo_dir.path().join("seed");
-    run_git(&bare, &["worktree", "add", seed.to_str().unwrap(), "-b", "main"]);
+    run_git(
+        &bare,
+        &["worktree", "add", seed.to_str().unwrap(), "-b", "main"],
+    );
     run_git(&seed, &["config", "user.email", "test@example.com"]);
     run_git(&seed, &["config", "user.name", "Test"]);
     run_git(&seed, &["commit", "--allow-empty", "-m", "seed"]);

--- a/iso-code/tests/proptest_porcelain.rs
+++ b/iso-code/tests/proptest_porcelain.rs
@@ -23,7 +23,7 @@ struct BlockSpec {
     branch: Option<String>,
     bare: bool,
     detached: bool,
-    locked: Option<Option<String>>,  // Some(None) = locked no reason; Some(Some(r)) = locked with reason.
+    locked: Option<Option<String>>, // Some(None) = locked no reason; Some(Some(r)) = locked with reason.
     prunable: Option<Option<String>>,
 }
 
@@ -38,10 +38,14 @@ fn safe_path(nul_delimited: bool) -> impl Strategy<Value = String> {
     // will never emit those in that mode.
     if nul_delimited {
         // -z mode: no NUL bytes, newlines ARE permitted in path.
-        "/[\\sA-Za-z0-9_\\-/\\.áéíñü ]{1,24}".prop_map(|s| s.to_string()).boxed()
+        "/[\\sA-Za-z0-9_\\-/\\.áéíñü ]{1,24}"
+            .prop_map(|s| s.to_string())
+            .boxed()
     } else {
         // Newline mode: paths must not contain newlines or NUL.
-        "/[A-Za-z0-9_\\-/\\. áéíñü]{1,24}".prop_map(|s| s.to_string()).boxed()
+        "/[A-Za-z0-9_\\-/\\. áéíñü]{1,24}"
+            .prop_map(|s| s.to_string())
+            .boxed()
     }
 }
 
@@ -55,20 +59,26 @@ fn block_spec(nul: bool) -> impl Strategy<Value = BlockSpec> {
         safe_path(nul),
         hex40(),
         prop::option::of(branch_name()),
-        any::<bool>(),  // bare
-        any::<bool>(),  // detached
-        prop::option::of(prop::option::of("[a-zA-Z0-9 ]{0,20}".prop_map(|s| s.to_string()))),
-        prop::option::of(prop::option::of("[a-zA-Z0-9 ]{0,20}".prop_map(|s| s.to_string()))),
+        any::<bool>(), // bare
+        any::<bool>(), // detached
+        prop::option::of(prop::option::of(
+            "[a-zA-Z0-9 ]{0,20}".prop_map(|s| s.to_string()),
+        )),
+        prop::option::of(prop::option::of(
+            "[a-zA-Z0-9 ]{0,20}".prop_map(|s| s.to_string()),
+        )),
     )
-        .prop_map(|(path, head, branch, bare, detached, locked, prunable)| BlockSpec {
-            path,
-            head,
-            branch,
-            bare,
-            detached,
-            locked,
-            prunable,
-        })
+        .prop_map(
+            |(path, head, branch, bare, detached, locked, prunable)| BlockSpec {
+                path,
+                head,
+                branch,
+                bare,
+                detached,
+                locked,
+                prunable,
+            },
+        )
 }
 
 /// Encode a block spec into porcelain bytes using the chosen separator.

--- a/iso-code/tests/regression.rs
+++ b/iso-code/tests/regression.rs
@@ -133,7 +133,11 @@ fn regression_qa_r_003_gc_force_preserves_active_worktrees_with_commits() {
             "gc force must not remove active worktree with unique commits: {}",
             h.path.display()
         );
-        assert!(h.path.exists(), "worktree dir must survive gc: {}", h.path.display());
+        assert!(
+            h.path.exists(),
+            "worktree dir must survive gc: {}",
+            h.path.display()
+        );
     }
 
     // All three branches must still exist
@@ -163,7 +167,11 @@ fn regression_qa_r_004_git_crypt_locked_auto_cleans() {
     // Fake a git-crypt configuration: .gitattributes flagging *.secret,
     // no key file in .git/git-crypt/keys/default, a *.secret file with the
     // git-crypt magic header in place (indicating encrypted content).
-    std::fs::write(repo.path().join(".gitattributes"), "*.secret filter=git-crypt diff=git-crypt\n").unwrap();
+    std::fs::write(
+        repo.path().join(".gitattributes"),
+        "*.secret filter=git-crypt diff=git-crypt\n",
+    )
+    .unwrap();
     run_git(repo.path(), &["add", ".gitattributes"]);
     run_git(repo.path(), &["commit", "-m", "add git-crypt attributes"]);
 
@@ -331,11 +339,7 @@ fn regression_qa_r_009_default_create_does_not_copy_node_modules() {
 
     // Simulate a JS repo: committed package.json plus an untracked, .gitignored
     // node_modules directory (the common real-world pattern).
-    std::fs::write(
-        repo.path().join(".gitignore"),
-        "node_modules/\n",
-    )
-    .unwrap();
+    std::fs::write(repo.path().join(".gitignore"), "node_modules/\n").unwrap();
     std::fs::write(
         repo.path().join("package.json"),
         r#"{ "name": "x", "version": "0.0.1" }"#,

--- a/iso-code/tests/stress_create_delete.rs
+++ b/iso-code/tests/stress_create_delete.rs
@@ -211,10 +211,7 @@ fn stress_100_cycles_sigkill() {
     );
 
     // state.json must be parseable.
-    let raw = std::fs::read(
-        iso_code::state::state_json_path(&repo_path, None),
-    )
-    .unwrap_or_default();
+    let raw = std::fs::read(iso_code::state::state_json_path(&repo_path, None)).unwrap_or_default();
     if !raw.is_empty() {
         serde_json::from_slice::<serde_json::Value>(&raw)
             .expect("state.json must be valid JSON after stress");
@@ -269,11 +266,16 @@ fn stress_sigkill_mid_operation_recovery() {
     let mgr = Manager::new(&repo_path, Config::default())
         .expect("Manager::new() after sigkill must succeed");
     let (handle, _) = mgr
-        .create("post-kill", repo_path.join("post-kill-wt"), CreateOptions::default())
+        .create(
+            "post-kill",
+            repo_path.join("post-kill-wt"),
+            CreateOptions::default(),
+        )
         .expect("create after sigkill must succeed");
     let mut o = DeleteOptions::default();
     o.force = true;
-    mgr.delete(&handle, o).expect("delete after sigkill must succeed");
+    mgr.delete(&handle, o)
+        .expect("delete after sigkill must succeed");
     assert!(
         start.elapsed() < Duration::from_secs(10),
         "full recovery + lifecycle should be fast: took {:?}",
@@ -322,7 +324,11 @@ fn stress_state_consistency_after_external_removal() {
     // Recreation on the same branch must succeed — the library must have
     // released any state-side references that would block it.
     let (h2, _) = mgr2
-        .create("ext-rm", repo.path().join("external-removal-wt-2"), CreateOptions::default())
+        .create(
+            "ext-rm",
+            repo.path().join("external-removal-wt-2"),
+            CreateOptions::default(),
+        )
         .expect("recreate after external removal must succeed");
     let mut f = DeleteOptions::default();
     f.force = true;

--- a/iso-code/tests/stress_gc_orphans.rs
+++ b/iso-code/tests/stress_gc_orphans.rs
@@ -62,7 +62,9 @@ fn stress_gc_small_scale() {
 
     // Cleanup regular worktrees
     for h in handles {
-        let mut o = DeleteOptions::default(); o.force = true; let _ = mgr.delete(&h, o);
+        let mut o = DeleteOptions::default();
+        o.force = true;
+        let _ = mgr.delete(&h, o);
     }
     // Cleanup locked worktrees
     for h in locked_handles {
@@ -87,13 +89,7 @@ fn stress_gc_1000_orphans() {
         let branch = format!("orphan-{i}");
         let wt_path = repo.path().join(format!("orphan-wt-{i}"));
         Command::new("git")
-            .args([
-                "worktree",
-                "add",
-                wt_path.to_str().unwrap(),
-                "-b",
-                &branch,
-            ])
+            .args(["worktree", "add", wt_path.to_str().unwrap(), "-b", &branch])
             .current_dir(repo.path())
             .output()
             .unwrap();
@@ -107,11 +103,17 @@ fn stress_gc_1000_orphans() {
 
     // GC dry run — should identify orphaned/prunable worktrees
     let start = std::time::Instant::now();
-    let mut go = GcOptions::default(); go.dry_run = true; go.force = true; let report = mgr.gc(go).unwrap();
+    let mut go = GcOptions::default();
+    go.dry_run = true;
+    go.force = true;
+    let report = mgr.gc(go).unwrap();
     let elapsed = start.elapsed();
 
     eprintln!("GC of {} worktrees took {:?}", list.len(), elapsed);
-    assert!(elapsed.as_secs() < 60, "GC should complete within 60 seconds");
+    assert!(
+        elapsed.as_secs() < 60,
+        "GC should complete within 60 seconds"
+    );
 
     // Cleanup
     for wt_path in &wt_paths {
@@ -149,7 +151,11 @@ fn stress_gc_locked_worktrees_untouched() {
     let report = mgr.gc(o).unwrap();
 
     for p in &locked_paths {
-        assert!(p.exists(), "locked worktree must still exist after gc: {}", p.display());
+        assert!(
+            p.exists(),
+            "locked worktree must still exist after gc: {}",
+            p.display()
+        );
         assert!(
             !report.removed.contains(p),
             "locked worktree must not be in removed: {}",

--- a/iso-code/tests/type_system.rs
+++ b/iso-code/tests/type_system.rs
@@ -108,10 +108,38 @@ fn gc_report_instantiates() {
 
 #[test]
 fn git_version_constants() {
-    assert_eq!(GitVersion::MINIMUM, GitVersion { major: 2, minor: 20, patch: 0 });
-    assert_eq!(GitVersion::HAS_LIST_NUL, GitVersion { major: 2, minor: 36, patch: 0 });
-    assert_eq!(GitVersion::HAS_REPAIR, GitVersion { major: 2, minor: 30, patch: 0 });
-    assert_eq!(GitVersion::HAS_MERGE_TREE_WRITE, GitVersion { major: 2, minor: 38, patch: 0 });
+    assert_eq!(
+        GitVersion::MINIMUM,
+        GitVersion {
+            major: 2,
+            minor: 20,
+            patch: 0
+        }
+    );
+    assert_eq!(
+        GitVersion::HAS_LIST_NUL,
+        GitVersion {
+            major: 2,
+            minor: 36,
+            patch: 0
+        }
+    );
+    assert_eq!(
+        GitVersion::HAS_REPAIR,
+        GitVersion {
+            major: 2,
+            minor: 30,
+            patch: 0
+        }
+    );
+    assert_eq!(
+        GitVersion::HAS_MERGE_TREE_WRITE,
+        GitVersion {
+            major: 2,
+            minor: 38,
+            patch: 0
+        }
+    );
 }
 
 #[test]
@@ -123,14 +151,7 @@ fn git_version_ordering() {
 
 #[test]
 fn git_capabilities_instantiates() {
-    let _c = GitCapabilities::new(
-        GitVersion::MINIMUM,
-        false,
-        false,
-        false,
-        false,
-        false,
-    );
+    let _c = GitCapabilities::new(GitVersion::MINIMUM, false, false, false, false, false);
 }
 
 #[test]

--- a/iso-code/tests/version_compat.rs
+++ b/iso-code/tests/version_compat.rs
@@ -86,8 +86,15 @@ fn qa_v_006_locked_prunable_absent_below_231() {
 #[test]
 fn qa_v_007_lock_flag_is_always_present_on_supported_versions() {
     let minimum = GitVersion::MINIMUM;
-    let flag_introduced = GitVersion { major: 2, minor: 17, patch: 0 };
-    assert!(minimum >= flag_introduced, "--lock flag must be present at our hard minimum");
+    let flag_introduced = GitVersion {
+        major: 2,
+        minor: 17,
+        patch: 0,
+    };
+    assert!(
+        minimum >= flag_introduced,
+        "--lock flag must be present at our hard minimum"
+    );
 }
 
 /// QA-V-008: Hard minimum version check — git 2.19 must be refused with a
@@ -118,13 +125,62 @@ fn qa_v_009_git_not_found_error_variant_exists() {
 fn mock_git_fixtures_report_their_tagged_versions() {
     use std::process::Command;
     for (tag, expected) in [
-        ("2.19", GitVersion { major: 2, minor: 19, patch: 0 }),
-        ("2.20", GitVersion { major: 2, minor: 20, patch: 0 }),
-        ("2.30", GitVersion { major: 2, minor: 30, patch: 0 }),
-        ("2.35", GitVersion { major: 2, minor: 35, patch: 1 }),
-        ("2.37", GitVersion { major: 2, minor: 37, patch: 4 }),
-        ("2.41", GitVersion { major: 2, minor: 41, patch: 0 }),
-        ("2.47", GitVersion { major: 2, minor: 47, patch: 2 }),
+        (
+            "2.19",
+            GitVersion {
+                major: 2,
+                minor: 19,
+                patch: 0,
+            },
+        ),
+        (
+            "2.20",
+            GitVersion {
+                major: 2,
+                minor: 20,
+                patch: 0,
+            },
+        ),
+        (
+            "2.30",
+            GitVersion {
+                major: 2,
+                minor: 30,
+                patch: 0,
+            },
+        ),
+        (
+            "2.35",
+            GitVersion {
+                major: 2,
+                minor: 35,
+                patch: 1,
+            },
+        ),
+        (
+            "2.37",
+            GitVersion {
+                major: 2,
+                minor: 37,
+                patch: 4,
+            },
+        ),
+        (
+            "2.41",
+            GitVersion {
+                major: 2,
+                minor: 41,
+                patch: 0,
+            },
+        ),
+        (
+            "2.47",
+            GitVersion {
+                major: 2,
+                minor: 47,
+                patch: 2,
+            },
+        ),
     ] {
         let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/mock-git")


### PR DESCRIPTION
## Summary

Closes #18.

`wt create`, `wt delete`, and `wt attach` validated only a **lower bound** on positional-argument count. Any extras were silently dropped. When a user forgot to quote a path containing spaces, the shell split it into multiple tokens — the CLI took the first chunk as the path and surfaced a misleading downstream error (e.g. `worktree path already exists`) instead of a clear usage error.

### Fix

- `run_create`: `args.len() < 2` → `args.len() != 2`
- `run_delete`: `args.is_empty()` → `args.len() != 1`
- `run_attach`: `args.is_empty()` → `args.len() != 1`

Short comment in `run_create` captures the *why* (shell-splitting on unquoted paths with spaces).

### Tests

New `iso-code-cli/tests/arg_count_validation.rs` (7 tests):

- Extra-arg rejection for `create`, `delete`, `attach` — verified to fail against the pre-fix code with the exact misleading errors the ticket describes.
- The ticket's unquoted-path repro (`/Users/kg/Documents/Documents - kg/projects/...`) now produces the `Usage:` message, not `already exists`.
- Zero-arg / too-few-arg invocations still produce `Usage:`.
- All tests run the binary from a non-repo tempdir, so any future regression can't corrupt the hosting repo.

### Commits

1. `chore: cargo fmt --all` — the repo had accumulated pre-existing formatting drift that was blocking the pre-commit hook. Pure whitespace / line-wrapping, no logic changes.
2. `fix(cli): …` — the actual 2-file fix + regression test.

## Test plan

- [x] `cargo test --workspace` — all pass (175+ tests)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] New regression tests fail against pre-fix code, pass after
- [x] `cargo fmt --all -- --check` — clean