### PR TITLE
fix(error): fix WorktreeLocked display leaking Option Debug format

### DIFF
--- a/iso-code/src/error.rs
+++ b/iso-code/src/error.rs
@@ -53,7 +53,7 @@ pub enum WorktreeError {
     #[error("cannot delete own working directory")]
     CannotDeleteCwd,
 
-    #[error("worktree is locked: {reason:?}")]
+    #[error("{}", match reason { Some(r) => format!("worktree is locked: {r}"), None => "worktree is locked".to_string() })]
     WorktreeLocked { reason: Option<String> },
 
     #[error("cannot create worktree inside existing worktree at '{parent}'")]
@@ -120,4 +120,23 @@ pub enum WorktreeError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worktree_locked_no_reason() {
+        let e = WorktreeError::WorktreeLocked { reason: None };
+        assert_eq!(e.to_string(), "worktree is locked");
+    }
+
+    #[test]
+    fn worktree_locked_with_reason() {
+        let e = WorktreeError::WorktreeLocked {
+            reason: Some("in-flight build".into()),
+        };
+        assert_eq!(e.to_string(), "worktree is locked: in-flight build");
+    }
 }


### PR DESCRIPTION
## Summary

- Replace `{reason:?}` (Debug formatting) on `WorktreeLocked` with a match expression
- `WorktreeLocked { reason: None }` now renders as `worktree is locked` (no `None` literal)
- `WorktreeLocked { reason: Some("foo") }` now renders as `worktree is locked: foo` (no `Some(...)` wrapper)
- Add unit tests covering both cases

Closes #19

## Test plan

- [ ] `cargo test --workspace` passes (new unit tests in `error.rs` cover both render cases)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --all` clean
- [ ] Manual: `wt delete` on a locked worktree with no reason no longer shows `None`