### PR TITLE
fix(error): add recovery hint to WorktreePathExists message

### DIFF
--- a/iso-code/src/error.rs
+++ b/iso-code/src/error.rs
@@ -14,7 +14,7 @@ pub enum WorktreeError {
     #[error("branch '{branch}' is already checked out at '{worktree}'")]
     BranchAlreadyCheckedOut { branch: String, worktree: PathBuf },
 
-    #[error("worktree path already exists: {0}")]
+    #[error("worktree path already exists: {0} — pick a path that doesn't exist yet; iso-code will create it (e.g. a sibling like ../<name>-<branch>)")]
     WorktreePathExists(PathBuf),
 
     #[error("uncommitted changes in worktree — use force_dirty to override: {files:?}")]
@@ -120,4 +120,20 @@ pub enum WorktreeError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worktree_path_exists_includes_path_and_hint() {
+        let e = WorktreeError::WorktreePathExists(PathBuf::from("/Users/foo/mitd"));
+        let msg = e.to_string();
+        assert!(msg.contains("/Users/foo/mitd"), "path missing from message");
+        assert!(
+            msg.contains("doesn't exist yet"),
+            "recovery hint missing from message"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `WorktreePathExists` now renders as:
  `worktree path already exists: <path> — pick a path that doesn't exist yet; iso-code will create it (e.g. a sibling like ../<name>-<branch>)`
- Gives new users a clear signal that the second arg to `wt create` must be a *new* directory, not the project root
- Unit test added asserting both the offending path and the hint appear in the message

Closes #22

## Test plan

- [ ] `cargo test --workspace` passes (new unit test in `error.rs`)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --all` clean
- [ ] Existing guards_matrix / concurrency tests still pass (they match on the variant, not the message substring)