### PR TITLE
feat(cli): add --setup flag to wt create with TOML adapter config

### DIFF
--- a/iso-code-cli/Cargo.toml
+++ b/iso-code-cli/Cargo.toml
@@ -22,6 +22,7 @@ iso-code = { version = "0.1.1", path = "../iso-code" }
 dunce = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/iso-code-cli/src/config.rs
+++ b/iso-code-cli/src/config.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+
+use iso_code::{DefaultAdapter, EcosystemAdapter, ShellCommandAdapter};
+
+/// Adapter configuration as read from `.iso-code.toml` or `config.toml`.
+///
+/// TOML examples:
+/// ```toml
+/// [adapter]
+/// type = "shell-command"
+/// post_create = "npm install"
+/// pre_delete  = "npm run cleanup"
+/// timeout_ms  = 60000
+/// ```
+/// ```toml
+/// [adapter]
+/// type = "default"
+/// files_to_copy = [".env", ".env.local"]
+/// ```
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum AdapterConfig {
+    ShellCommand {
+        post_create: Option<String>,
+        pre_delete: Option<String>,
+        post_delete: Option<String>,
+        timeout_ms: Option<u64>,
+    },
+    Default {
+        #[serde(default)]
+        files_to_copy: Vec<String>,
+    },
+}
+
+#[derive(serde::Deserialize, Default)]
+pub struct CliConfig {
+    pub adapter: Option<AdapterConfig>,
+}
+
+/// Load CLI config from the first file found in this order:
+/// 1. `<repo_root>/.iso-code.toml`  (project-local, highest priority)
+/// 2. `$HOME/.config/iso-code/config.toml`  (user-level)
+pub fn load_config(repo_root: &Path) -> CliConfig {
+    let local = repo_root.join(".iso-code.toml");
+    if local.exists() {
+        if let Some(cfg) = read_toml(&local) {
+            return cfg;
+        }
+    }
+
+    if let Some(home) = home_dir() {
+        let user = home.join(".config").join("iso-code").join("config.toml");
+        if user.exists() {
+            if let Some(cfg) = read_toml(&user) {
+                return cfg;
+            }
+        }
+    }
+
+    CliConfig::default()
+}
+
+/// Instantiate the adapter described by `cfg`.
+pub fn build_adapter(cfg: &AdapterConfig) -> Box<dyn EcosystemAdapter> {
+    match cfg {
+        AdapterConfig::ShellCommand {
+            post_create,
+            pre_delete,
+            post_delete,
+            timeout_ms,
+        } => {
+            let mut a = ShellCommandAdapter::new();
+            if let Some(cmd) = post_create {
+                a = a.with_post_create(cmd.as_str());
+            }
+            if let Some(cmd) = pre_delete {
+                a = a.with_pre_delete(cmd.as_str());
+            }
+            if let Some(cmd) = post_delete {
+                a = a.with_post_delete(cmd.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                a = a.with_timeout_ms(*ms);
+            }
+            Box::new(a)
+        }
+        AdapterConfig::Default { files_to_copy } => {
+            let files = files_to_copy.iter().map(PathBuf::from).collect();
+            Box::new(DefaultAdapter::new(files))
+        }
+    }
+}
+
+fn read_toml(path: &Path) -> Option<CliConfig> {
+    let content = std::fs::read_to_string(path).ok()?;
+    toml::from_str(&content).ok()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}

--- a/iso-code-cli/src/main.rs
+++ b/iso-code-cli/src/main.rs
@@ -4,6 +4,8 @@ use std::process;
 
 use iso_code::{AttachOptions, Config, CreateOptions, GcOptions, Manager};
 
+mod config;
+
 #[derive(serde::Deserialize)]
 struct ClaudeCodeHookPayload {
     #[serde(default)]
@@ -186,26 +188,73 @@ fn run_list(args: &[String]) {
     }
 }
 
-/// `wt create <branch> <path>`
+/// `wt create <branch> <path> [--setup]`
 fn run_create(args: &[String]) {
-    if args.len() != 2 {
-        eprintln!("[iso-code] Usage: wt create <branch> <path>");
+    let mut setup = false;
+
+    let positional: Vec<&String> = args
+        .iter()
+        .filter(|a| {
+            if a.as_str() == "--setup" {
+                setup = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if positional.len() != 2 {
+        eprintln!("[iso-code] Usage: wt create <branch> <path> [--setup]");
         process::exit(1);
     }
 
-    let branch = &args[0];
-    let path = PathBuf::from(&args[1]);
+    let branch = positional[0];
+    let path = PathBuf::from(positional[1]);
     let repo = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    let mgr = match Manager::new(&repo, Config::default()) {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("[iso-code] Error: {e}");
-            process::exit(1);
+    let mut opts = CreateOptions::default();
+
+    let mgr = if setup {
+        let cfg = config::load_config(&repo);
+        match cfg.adapter {
+            Some(ref adapter_cfg) => {
+                opts.setup = true;
+                let adapter = config::build_adapter(adapter_cfg);
+                match Manager::with_adapter(&repo, Config::default(), Some(adapter)) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("[iso-code] Error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            None => {
+                eprintln!(
+                    "[iso-code] Warning: --setup passed but no adapter configured \
+                     in .iso-code.toml or ~/.config/iso-code/config.toml — \
+                     proceeding without setup"
+                );
+                match Manager::new(&repo, Config::default()) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("[iso-code] Error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        }
+    } else {
+        match Manager::new(&repo, Config::default()) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("[iso-code] Error: {e}");
+                process::exit(1);
+            }
         }
     };
 
-    match mgr.create(branch, &path, CreateOptions::default()) {
+    match mgr.create(branch, &path, opts) {
         Ok((handle, _)) => {
             println!("{}", handle.path.display());
         }

--- a/iso-code-cli/tests/setup_flag.rs
+++ b/iso-code-cli/tests/setup_flag.rs
@@ -1,0 +1,337 @@
+use std::path::Path;
+use std::process::Command;
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    if !out.status.success() {
+        panic!("git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    }
+}
+
+fn create_test_repo() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    run_git(dir.path(), &["init", "-b", "main"]);
+    run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "Test"]);
+    run_git(dir.path(), &["commit", "--allow-empty", "-m", "initial"]);
+    dir
+}
+
+fn wt(cwd: &Path) -> assert_cmd::Command {
+    let mut cmd = assert_cmd::Command::cargo_bin("wt").expect("wt binary");
+    cmd.current_dir(cwd);
+    cmd
+}
+
+// ── shell-command adapter ────────────────────────────────────────────────────
+
+#[test]
+fn setup_with_shell_command_adapter_runs_post_create() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("feature-wt");
+
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"touch .setup-done\"\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .args([
+            "create",
+            "feature-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "wt create --setup failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        wt_path.join(".setup-done").exists(),
+        "post_create must have created .setup-done"
+    );
+}
+
+#[test]
+fn setup_with_shell_command_records_adapter_in_state() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("state-wt");
+
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"echo ok\"\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .args([
+            "create",
+            "state-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // state.json should record the adapter name
+    let state_path = repo.path().join(".git").join("iso-code").join("state.json");
+    let state = std::fs::read_to_string(&state_path).unwrap();
+    assert!(
+        state.contains("shell-command"),
+        "state.json must record adapter name; got:\n{state}"
+    );
+}
+
+// ── default adapter ──────────────────────────────────────────────────────────
+
+#[test]
+fn setup_with_default_adapter_copies_env_file() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("default-wt");
+
+    std::fs::write(repo.path().join(".env"), "API_KEY=secret").unwrap();
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"default\"\nfiles_to_copy = [\".env\"]\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .args([
+            "create",
+            "default-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        wt_path.join(".env").exists(),
+        "DefaultAdapter must have copied .env into the new worktree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(wt_path.join(".env")).unwrap(),
+        "API_KEY=secret"
+    );
+}
+
+// ── no-config warning ────────────────────────────────────────────────────────
+
+#[test]
+fn setup_without_config_warns_and_succeeds() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("no-config-wt");
+
+    // No .iso-code.toml written — adapter is absent.
+
+    let out = wt(repo.path())
+        .args([
+            "create",
+            "no-config-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "--setup without config must succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(wt_path.exists(), "worktree directory must still be created");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Warning") && stderr.contains("no adapter configured"),
+        "must warn on stderr; got: {stderr}"
+    );
+}
+
+// ── without --setup flag ─────────────────────────────────────────────────────
+
+#[test]
+fn create_without_setup_does_not_run_adapter() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("no-setup-wt");
+
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"touch .setup-done\"\n",
+    )
+    .unwrap();
+
+    // No --setup flag
+    let out = wt(repo.path())
+        .args(["create", "no-setup-branch", wt_path.to_str().unwrap()])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !wt_path.join(".setup-done").exists(),
+        "adapter must NOT run when --setup is absent"
+    );
+}
+
+// ── stdout purity ────────────────────────────────────────────────────────────
+
+#[test]
+fn stdout_contains_only_worktree_path_when_setup_runs() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("clean-stdout-wt");
+
+    // Use a post_create that emits output — it must NOT leak to stdout.
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"echo THIS_MUST_NOT_APPEAR_ON_STDOUT\"\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .args([
+            "create",
+            "clean-stdout-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout must be UTF-8");
+    assert!(
+        !stdout.contains("THIS_MUST_NOT_APPEAR_ON_STDOUT"),
+        "adapter output must not leak to stdout; got: {stdout:?}"
+    );
+    // stdout must be exactly one newline-terminated absolute path
+    let path_str = stdout.trim_end_matches('\n');
+    assert!(
+        !path_str.contains('\n'),
+        "stdout must be one line: {stdout:?}"
+    );
+    assert!(
+        Path::new(path_str).is_absolute(),
+        "stdout must be an absolute path: {path_str}"
+    );
+}
+
+// ── project-local config takes precedence ───────────────────────────────────
+
+#[test]
+fn project_local_config_takes_precedence_over_user_config() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("precedence-wt");
+
+    // Write a project-local config that creates .project-config-ran
+    std::fs::write(
+        repo.path().join(".iso-code.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"touch .project-config-ran\"\n",
+    )
+    .unwrap();
+
+    // Simulate a user config by setting HOME to a temp dir that has a
+    // config.toml with a different marker.
+    let fake_home = tempfile::TempDir::new().unwrap();
+    let user_cfg_dir = fake_home.path().join(".config").join("iso-code");
+    std::fs::create_dir_all(&user_cfg_dir).unwrap();
+    std::fs::write(
+        user_cfg_dir.join("config.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"touch .user-config-ran\"\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .env("HOME", fake_home.path())
+        .args([
+            "create",
+            "precedence-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        wt_path.join(".project-config-ran").exists(),
+        "project-local config must win"
+    );
+    assert!(
+        !wt_path.join(".user-config-ran").exists(),
+        "user config must not run when project-local config is present"
+    );
+}
+
+// ── user-level config fallback ───────────────────────────────────────────────
+
+#[test]
+fn user_config_used_when_no_project_local_config() {
+    let repo = create_test_repo();
+    let wt_path = repo.path().join("user-cfg-wt");
+
+    // No .iso-code.toml in repo root.
+    let fake_home = tempfile::TempDir::new().unwrap();
+    let user_cfg_dir = fake_home.path().join(".config").join("iso-code");
+    std::fs::create_dir_all(&user_cfg_dir).unwrap();
+    std::fs::write(
+        user_cfg_dir.join("config.toml"),
+        "[adapter]\ntype = \"shell-command\"\npost_create = \"touch .user-setup-done\"\n",
+    )
+    .unwrap();
+
+    let out = wt(repo.path())
+        .env("HOME", fake_home.path())
+        .args([
+            "create",
+            "user-cfg-branch",
+            wt_path.to_str().unwrap(),
+            "--setup",
+        ])
+        .output()
+        .expect("spawn wt");
+
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        wt_path.join(".user-setup-done").exists(),
+        "user-level config must be used as fallback"
+    );
+}


### PR DESCRIPTION
## Summary

- New `--setup` flag on `wt create <branch> <path> [--setup]`
- Reads adapter config from `.iso-code.toml` (project-local) or `~/.config/iso-code/config.toml` (user-level fallback)
- Builds and registers `ShellCommandAdapter` or `DefaultAdapter` based on the `[adapter]` section
- If `--setup` is passed with no config: warns on stderr, creates worktree without setup (no error)
- If `--setup` is absent: config file is ignored, no adapter runs
- stdout remains a single clean path (`<absolute-path>\n`) — no adapter output leaks through (stdout suppressed in `ShellCommandAdapter`)
- New `iso-code-cli/src/config.rs` module handles TOML deserialization and adapter factory

**Config format:**
```toml
# .iso-code.toml
[adapter]
type = "shell-command"
post_create = "npm install"
pre_delete  = "npm run cleanup"
timeout_ms  = 60000
```
```toml
[adapter]
type = "default"
files_to_copy = [".env", ".env.local"]
```

Closes #8

## Test plan

- [x] `setup_with_shell_command_adapter_runs_post_create` — post_create command runs, marker file created
- [x] `setup_with_shell_command_records_adapter_in_state` — `state.json` contains `"shell-command"` after `--setup`
- [x] `setup_with_default_adapter_copies_env_file` — `.env` copied into new worktree
- [x] `setup_without_config_warns_and_succeeds` — warning on stderr, worktree created, exit 0
- [x] `create_without_setup_does_not_run_adapter` — adapter config present but flag absent → adapter never runs
- [x] `stdout_contains_only_worktree_path_when_setup_runs` — `echo` output from post_create doesn't appear on stdout
- [x] `project_local_config_takes_precedence_over_user_config` — `.iso-code.toml` wins over `~/.config/iso-code/config.toml`
- [x] `user_config_used_when_no_project_local_config` — user-level config used as fallback
- [x] All existing tests still pass (arg count validation, hook contract, version compat, full library suite)